### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/mgd43b/shelldbhist/security/code-scanning/1](https://github.com/mgd43b/shelldbhist/security/code-scanning/1)

To fix the problem, explicitly scope the `GITHUB_TOKEN` permissions used by this workflow to the minimal set required. Since this CI job only checks out code and runs Rust tooling (fmt, clippy, test) without pushing changes, creating releases, or modifying issues/PRs, it only needs read access to repository contents.

The best minimal fix, without changing existing functionality, is to add a `permissions` block under the `test` job in `.github/workflows/ci.yml`, specifying `contents: read`. This ensures the `GITHUB_TOKEN` associated with this job can only read repository contents and cannot perform write operations. Concretely, in `.github/workflows/ci.yml`, edit the `jobs.test` section so that immediately after the `test:` line (line 9), you insert:

```yaml
    permissions:
      contents: read
```

No additional imports, methods, or definitions are required, as this is a pure workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
