### PR TITLE
fix: exit quietly on SIGPIPE instead of panicking when stdout closes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,13 +708,14 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "sdbh"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
  "dialoguer",
  "dirs",
+ "libc",
  "predicates",
  "regex",
  "rusqlite",

--- a/sdbh/Cargo.toml
+++ b/sdbh/Cargo.toml
@@ -11,6 +11,9 @@ clap = { version = "4.6.1", features = ["derive"] }
 # (Optional) used to resolve ~/.sdbh.toml robustly.
 dialoguer = "0.12.0"
 dirs = "6.0.0"
+# Restore default SIGPIPE handling so piping to `head`/`grep` exits quietly
+# instead of panicking (see `reset_sigpipe` in main.rs).
+libc = "0.2"
 regex = "1.12.3"
 rusqlite = { version = "0.40.0" }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/sdbh/src/main.rs
+++ b/sdbh/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use clap::Parser;
 
 fn main() -> Result<()> {
-    reset_sigpipe();
+    reset_sigpipe()?;
     let cli = cli::Cli::parse();
     cli::run(cli)
 }
@@ -23,13 +23,22 @@ fn main() -> Result<()> {
 /// makes the process terminate quietly on `SIGPIPE`, matching standard Unix
 /// filters like `grep`/`cat`.
 #[cfg(unix)]
-fn reset_sigpipe() {
+fn reset_sigpipe() -> Result<()> {
     // SAFETY: called once at the very start of `main`, before any other threads
     // exist; `signal(2)` with `SIG_DFL` is async-signal-safe.
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    let prev = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
+    if prev == libc::SIG_ERR {
+        // Practically unreachable for SIGPIPE/SIG_DFL, but surface it loudly
+        // rather than silently continuing with the panic-prone SIG_IGN default.
+        return Err(anyhow::anyhow!(
+            "failed to restore default SIGPIPE handler: {}",
+            std::io::Error::last_os_error()
+        ));
     }
+    Ok(())
 }
 
 #[cfg(not(unix))]
-fn reset_sigpipe() {}
+fn reset_sigpipe() -> Result<()> {
+    Ok(())
+}

--- a/sdbh/src/main.rs
+++ b/sdbh/src/main.rs
@@ -9,6 +9,27 @@ use anyhow::Result;
 use clap::Parser;
 
 fn main() -> Result<()> {
+    reset_sigpipe();
     let cli = cli::Cli::parse();
     cli::run(cli)
 }
+
+/// Restore the default `SIGPIPE` disposition (`SIG_DFL`).
+///
+/// Rust installs `SIG_IGN` for `SIGPIPE` at startup, which turns a closed
+/// downstream pipe (e.g. `sdbh export | head`, or `sdbha | grep …` where grep
+/// exits early) into an `EPIPE` error that the `println!` machinery unwraps —
+/// panicking with "failed printing to stdout: Broken pipe". Restoring `SIG_DFL`
+/// makes the process terminate quietly on `SIGPIPE`, matching standard Unix
+/// filters like `grep`/`cat`.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // SAFETY: called once at the very start of `main`, before any other threads
+    // exist; `signal(2)` with `SIG_DFL` is async-signal-safe.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}

--- a/sdbh/src/main.rs
+++ b/sdbh/src/main.rs
@@ -27,9 +27,18 @@ fn reset_sigpipe() -> Result<()> {
     // SAFETY: called once at the very start of `main`, before any other threads
     // exist; `signal(2)` with `SIG_DFL` is async-signal-safe.
     let prev = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
+    sigpipe_result(prev)
+}
+
+/// Map the return value of `signal(2)` to a `Result`, erroring on `SIG_ERR`.
+///
+/// Split out from [`reset_sigpipe`] so the (practically unreachable) failure
+/// path can be unit-tested without having to make a real `signal` call fail.
+#[cfg(unix)]
+fn sigpipe_result(prev: libc::sighandler_t) -> Result<()> {
     if prev == libc::SIG_ERR {
-        // Practically unreachable for SIGPIPE/SIG_DFL, but surface it loudly
-        // rather than silently continuing with the panic-prone SIG_IGN default.
+        // Surface it loudly rather than silently continuing with the
+        // panic-prone SIG_IGN default that Rust installs.
         return Err(anyhow::anyhow!(
             "failed to restore default SIGPIPE handler: {}",
             std::io::Error::last_os_error()
@@ -41,4 +50,20 @@ fn reset_sigpipe() -> Result<()> {
 #[cfg(not(unix))]
 fn reset_sigpipe() -> Result<()> {
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::sigpipe_result;
+
+    #[test]
+    fn sigpipe_result_ok_for_valid_previous_handler() {
+        // SIG_DFL is a normal previous-handler value, not an error sentinel.
+        assert!(sigpipe_result(libc::SIG_DFL).is_ok());
+    }
+
+    #[test]
+    fn sigpipe_result_errors_on_sig_err() {
+        assert!(sigpipe_result(libc::SIG_ERR).is_err());
+    }
 }

--- a/sdbh/tests/integration.rs
+++ b/sdbh/tests/integration.rs
@@ -4895,3 +4895,64 @@ required = true
         assert!(result.status.success());
     }
 }
+
+/// Regression test: writing to a closed stdout (e.g. `sdbh export | head`, or
+/// `sdbha | grep …` where grep exits early) must not panic with "failed
+/// printing to stdout: Broken pipe". `main` restores the default SIGPIPE
+/// handler so the process is terminated quietly by SIGPIPE instead. See
+/// `reset_sigpipe` in `src/main.rs`.
+#[test]
+#[cfg(unix)]
+fn writing_to_closed_pipe_does_not_panic() {
+    use std::io::Read;
+    use std::process::{Command as StdCommand, Stdio};
+
+    let tmp = TempDir::new().unwrap();
+    let db = tmp.path().join("test.sqlite");
+
+    // A single row whose command is large enough that `export` output well
+    // exceeds the OS pipe buffer, so a reader that closes early forces an
+    // EPIPE mid-write.
+    let big_cmd = format!("echo {}", "x".repeat(120_000));
+    sdbh_cmd()
+        .args([
+            "--db",
+            db.to_string_lossy().as_ref(),
+            "log",
+            "--cmd",
+            &big_cmd,
+            "--epoch",
+            "1700000000",
+            "--ppid",
+            "1",
+            "--pwd",
+            "/tmp",
+            "--salt",
+            "1",
+        ])
+        .assert()
+        .success();
+
+    let exe = assert_cmd::cargo::cargo_bin!("sdbh");
+    let mut child = StdCommand::new(exe)
+        .args(["--db", db.to_string_lossy().as_ref(), "export"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // Read only a few bytes, then drop the read end to close the pipe while
+    // the child is still blocked writing the rest.
+    {
+        let mut out = child.stdout.take().unwrap();
+        let mut buf = [0u8; 8];
+        let _ = out.read(&mut buf);
+    }
+
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("Broken pipe"),
+        "sdbh panicked writing to a closed pipe instead of exiting quietly:\n{stderr}"
+    );
+}

--- a/sdbh/tests/integration.rs
+++ b/sdbh/tests/integration.rs
@@ -4905,6 +4905,7 @@ required = true
 #[cfg(unix)]
 fn writing_to_closed_pipe_does_not_panic() {
     use std::io::Read;
+    use std::os::unix::process::ExitStatusExt;
     use std::process::{Command as StdCommand, Stdio};
 
     let tmp = TempDir::new().unwrap();
@@ -4954,5 +4955,16 @@ fn writing_to_closed_pipe_does_not_panic() {
     assert!(
         !stderr.contains("panicked") && !stderr.contains("Broken pipe"),
         "sdbh panicked writing to a closed pipe instead of exiting quietly:\n{stderr}"
+    );
+
+    // Guard against a hollow pass: the process must have either finished
+    // cleanly (wrote everything before the reader closed) or been terminated
+    // by SIGPIPE (signal 13, portable across Linux/macOS). A panic would exit
+    // with code 101 — signal() == None — and fail here even if stderr were
+    // somehow empty.
+    let status = output.status;
+    assert!(
+        status.success() || status.signal() == Some(13),
+        "expected a clean exit or SIGPIPE termination, got {status:?}\nstderr:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Bug

Piping `sdbh` output into a reader that exits early panics instead of stopping cleanly:

```
$ sdbha | grep update- tap
grep: tap: No such file or directory
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
```

This hits any subcommand with substantial stdout piped to `head`, `grep`, `less -q`, etc.

## Root cause

Rust installs `SIG_IGN` for `SIGPIPE` at startup, so a closed downstream pipe surfaces as an `EPIPE` error that the `println!` machinery unwraps → panic. (231 `print!`/`println!` call sites, so per-call error handling isn't practical.)

## Fix

Restore the default `SIGPIPE` disposition (`SIG_DFL`) at the very start of `main`, so the process terminates quietly on `SIGPIPE` like standard Unix filters (`grep`/`cat`). This is the same approach used by ripgrep, fd, and bat. Adds a `libc` dependency (already in the tree transitively).

## Tests / verification

- New regression test `writing_to_closed_pipe_does_not_panic` — reproduces the exact scenario (large `export` output, reader closes after a few bytes). Verified it **fails without the fix** (panics) and **passes with it**; ran 3× for flakiness.
- Full suite green (104 integration + others), `cargo fmt --check` ✅, `cargo clippy -- -D warnings` ✅.
- Manually reproduced the panic on the unfixed binary and confirmed it's gone after the fix; normal (unpiped) output is unchanged.

Also reconciles `Cargo.lock` (still had `sdbh` at 1.0.2 after the 1.0.3 release) and registers `libc` as a direct dependency.