### PR TITLE
ci: auto-dispatch dist Release workflow after release-please tags a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,12 +9,15 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed to dispatch the "Release" (dist) workflow after a release is cut.
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v5
         with:
           # We have a single releasable unit: the sdbh crate.
@@ -24,3 +27,19 @@ jobs:
           # Tag format will be vX.Y.Z
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please creates the tag with GITHUB_TOKEN, and GitHub does not
+      # trigger workflow runs from tag pushes made with GITHUB_TOKEN. So the
+      # `on: push: tags:` trigger in release.yml (dist) never fires and no
+      # artifacts get built. workflow_dispatch is the documented exception that
+      # DOES run even when invoked with GITHUB_TOKEN, so dispatch the Release
+      # workflow explicitly for the freshly created tag.
+      - name: Trigger dist Release workflow for the new tag
+        if: ${{ steps.release.outputs.releases_created == 'true' || steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ steps.release.outputs.tag_name || steps.release.outputs['sdbh--tag_name'] }}
+        run: |
+          echo "Dispatching Release workflow for tag: $TAG_NAME"
+          gh workflow run release.yml -f tag="$TAG_NAME"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,5 +41,13 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ steps.release.outputs.tag_name || steps.release.outputs['sdbh--tag_name'] }}
         run: |
-          echo "Dispatching Release workflow for tag: $TAG_NAME"
-          gh workflow run release.yml -f tag="$TAG_NAME"
+          if [ -z "$TAG_NAME" ]; then
+            echo "::error::release was created but no tag name was resolved from release-please outputs" >&2
+            exit 1
+          fi
+          # Dispatch on the tag ref (not the default branch) so release.yml checks
+          # out and builds the exact tagged commit, even if main advances before
+          # the dispatched run starts. The tag contains release.yml, so it is a
+          # valid ref to dispatch against.
+          echo "Dispatching Release workflow on tag ref: $TAG_NAME"
+          gh workflow run release.yml --ref "$TAG_NAME" -f tag="$TAG_NAME"


### PR DESCRIPTION
## Problem

v1.0.3 was tagged/released but **built no artifacts**. Root cause: release-please creates the version tag using the default `GITHUB_TOKEN`, and GitHub **does not trigger workflow runs from tag pushes made with `GITHUB_TOKEN`** (a guard against recursive runs). So `release.yml` (dist), which builds on `push: tags: 'v*'`, never fired — the Release workflow only ever ran in `pull_request` plan mode.

## Fix

`workflow_dispatch` and `repository_dispatch` are the [documented exceptions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) that **do** run even when invoked with `GITHUB_TOKEN`. So after release-please cuts a release, dispatch the Release workflow explicitly for the new tag:

```yaml
- name: Trigger dist Release workflow for the new tag
  if: ${{ steps.release.outputs.releases_created == 'true' || steps.release.outputs.release_created == 'true' }}
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    GH_REPO: ${{ github.repository }}
    TAG_NAME: ${{ steps.release.outputs.tag_name || steps.release.outputs['sdbh--tag_name'] }}
  run: gh workflow run release.yml -f tag="$TAG_NAME"
```

release.yml already supports this via its `workflow_dispatch` `tag` input (the same path used to manually rebuild v1.0.3).

- **No PAT/secret required** — uses the built-in `GITHUB_TOKEN`; only adds `actions: write` permission.
- Guards on both `releases_created` (manifest mode) and `release_created`, and resolves the tag from either `tag_name` or the `sdbh--tag_name` manifest output, so it's robust to the action's output naming.
- No new run unless a release is actually created (no dispatch on plain release-PR updates).

Validated with `actionlint` (clean) and a YAML parse check.

## Note

Fixes releases going forward (e.g. 1.0.4 from #126). v1.0.3's artifacts were already backfilled via a manual `workflow_dispatch`.